### PR TITLE
feat: integrate gpu vm pores and wrinkles cutover

### DIFF
--- a/.github/workflows/deploy-azure-function-api.yml
+++ b/.github/workflows/deploy-azure-function-api.yml
@@ -1,0 +1,45 @@
+name: Deploy Azure Function API
+
+on:
+  workflow_dispatch:
+    inputs:
+      function_app_name:
+        description: Azure Function App name
+        required: true
+        default: new-skincare-advisor-api-fqc8dffvg5ghene2
+      ref:
+        description: Git ref to deploy
+        required: true
+        default: shopify-compliance
+
+jobs:
+  deploy_api:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install API dependencies
+        working-directory: ./api
+        run: npm ci
+
+      - name: Deploy Function App
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ inputs.function_app_name }}
+          package: ./api
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
+          scm-do-build-during-deployment: true
+          enable-oryx-build: true

--- a/api/infer/index.js
+++ b/api/infer/index.js
@@ -9,6 +9,7 @@ const { rateLimitMiddleware } = require('../shared/rateLimit');
 const cache = require('../shared/cache');
 const { enrichWithRecommendations } = require('../shared/recommendations');
 const { calculateSkinMetrics, getBenchmarks } = require('../shared/skinMetrics');
+const { mapCombinedPoresWrinklesResult, mergeWrinklesData } = require('./poresWrinklesMapper');
 const { v4: uuidv4 } = require('uuid');
 
 const logger = createLogger('infer');
@@ -671,17 +672,20 @@ module.exports = async function (context, req) {
       }
     }
     
-    const wrinklesData = wrinklesResp.status === 'fulfilled' ? wrinklesResp.value : {
+    const legacyWrinklesData = wrinklesResp.status === 'fulfilled' ? wrinklesResp.value : {
       predictions: [],
       image: { width: 0, height: 0 },
       time: 0,
       wrinkleSeverity: { overall: { severity: 1 } }
     };
 
-    // Pores: null when failed/timed-out — skinMetrics.pores stays null gracefully
-    const poresData = (poresResp.status === 'fulfilled' && poresResp.value !== null)
-      ? poresResp.value
-      : null;
+    let poresData = null;
+    let combinedWrinklesData = null;
+    if (poresResp.status === 'fulfilled' && poresResp.value !== null) {
+      ({ poresData, wrinklesData: combinedWrinklesData } = poresResp.value);
+    }
+
+    const wrinklesData = mergeWrinklesData(legacyWrinklesData, combinedWrinklesData);
 
     // Calculate erythema from redness predictedClass
     const rednessClass = laxityRednessData.predictions?.redness?.predictedClass || 1;
@@ -1313,62 +1317,7 @@ async function callPoresAPI(base64Image) {
     pore_severity_1_5: r.summary?.aggregate?.pore_severity_1_5
   });
 
-  const poreSeverity = r.summary?.analysis?.pore_severity ?? {};
-  const assessment = r.summary?.analysis?.assessment ?? {};
-  const poreMetrics = r.summary?.analysis?.pore_metrics ?? {};
-  const regionBreakdown = r.summary?.analysis?.region_breakdown ?? {};
-  const preprocess = r.preprocess ?? r.summary?.yolo_pores?.preprocess ?? {};
-
-  // Project region bounding boxes — bbox_full is already in original-image pixel space
-  const regions = {};
-  for (const [region, data] of Object.entries(regionBreakdown)) {
-    if (data && typeof data === 'object') {
-      regions[region] = {
-        bbox_full: data.bbox_full ?? null,     // coordinates on the original selfie (pixels)
-        pore_count: data.pores?.metrics?.count ?? 0,
-        visible_count: data.pores?.metrics?.visible_count ?? 0,
-        visible_fraction: data.pores?.metrics?.visible_fraction ?? null,
-        quality_visibility: data.quality?.visibility ?? null,
-      };
-    }
-  }
-
-  return {
-    job_id,
-    // Aggregate counts + severity (1–5 scale)
-    pore_total: r.summary?.aggregate?.pore_total ?? 0,
-    pore_severity_1_5: r.summary?.aggregate?.pore_severity_1_5 ?? null,
-    pore_size_severity_1_5: r.summary?.aggregate?.pore_size_severity_1_5 ?? null,
-    // Severity detail
-    score_label: poreSeverity.score_label ?? null,          // "minimal"|"mild"|"moderate"|"high"|"very_high"
-    score_0_100: poreSeverity.score_0_100 ?? null,          // normalized 0-100 index
-    // Visible pore stats (pores clearly detectable vs low-contrast)
-    visible_count: poreMetrics.visible_count ?? null,
-    visible_fraction: poreMetrics.visible_fraction ?? null, // 0.0-1.0
-    // Assessment flags
-    large_pores_present: assessment.large_pores_present ?? null,
-    pores_visibility: assessment.pores_visibility ?? null,  // "low"|"medium"|"high"
-    // Per-region breakdown with bbox_full in original image coordinates
-    // → use these to draw colored region overlays on the selfie in the frontend
-    regions,
-    // Preprocessor metadata (crop_bbox + resized_scale needed to map crop-space → original space)
-    preprocess: {
-      crop_bbox: preprocess.crop_bbox ?? null,
-      resized_scale: preprocess.resized_scale ?? null,
-      resized_from: preprocess.resized_from ?? null,
-    },
-    // Pre-rendered overlay image — easiest path for frontend display
-    overlay_preview_url: r.selected_overlay_preview_url
-      ? `${apiUrl}${r.selected_overlay_preview_url}`
-      : null,
-    overlay_url: r.selected_overlay_url
-      ? `${apiUrl}${r.selected_overlay_url}`
-      : null,
-    // Circles-only overlay: pores rendered as green dots only, no region masks
-    overlay_circles_preview_url: r.overlay_preview_urls?.pores_circles
-      ? `${apiUrl}${r.overlay_preview_urls.pores_circles}`
-      : null,
-  };
+  return mapCombinedPoresWrinklesResult({ ...r, job_id }, apiUrl);
 }
 
 /**

--- a/api/infer/index.js
+++ b/api/infer/index.js
@@ -17,7 +17,7 @@ const logger = createLogger('infer');
 const disableCache =
   (process.env.DISABLE_INFER_CACHE || '').toLowerCase() === 'true';
 const inferSyncBudgetMs = Math.max(
-  parseInt(process.env.INFER_SYNC_BUDGET_MS || '', 10) || 58000,
+  parseInt(process.env.INFER_SYNC_BUDGET_MS || '', 10) || 300000,
   1000
 );
 const inferRecommendationsReserveMs = Math.max(

--- a/api/infer/poresWrinklesMapper.js
+++ b/api/infer/poresWrinklesMapper.js
@@ -1,0 +1,203 @@
+const WRINKLE_REGION_LABELS = {
+  forehead: 'Forehead',
+  under_eye_left: 'Under-eye Left',
+  under_eye_right: 'Under-eye Right',
+  cheek_left: 'Left Cheek',
+  cheek_right: 'Right Cheek',
+  nose: 'Nose',
+  perioral: 'Perioral',
+};
+
+function toAbsoluteApiUrl(apiUrl, maybePath) {
+  if (!maybePath || typeof maybePath !== 'string') return null;
+  if (/^https?:\/\//i.test(maybePath)) return maybePath;
+  if (!apiUrl) return maybePath;
+  if (maybePath.startsWith('/')) return `${apiUrl}${maybePath}`;
+  return `${apiUrl}/${maybePath}`;
+}
+
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function deriveWrinkleSeverityFromTotal(wrinkleTotal) {
+  const total = Math.max(0, Math.round(toFiniteNumber(wrinkleTotal) ?? 0));
+  if (total === 0) return 1;
+  if (total <= 10) return 2;
+  if (total <= 25) return 3;
+  if (total <= 40) return 4;
+  return 5;
+}
+
+function mapCombinedPoresWrinklesResult(resultPayload, apiUrl) {
+  const payload = resultPayload ?? {};
+  const summary = payload.summary ?? {};
+  const aggregate = summary.aggregate ?? {};
+  const analysis = summary.analysis ?? {};
+  const assessment = analysis.assessment ?? {};
+  const poreSeverity = analysis.pore_severity ?? {};
+  const poreMetrics = analysis.pore_metrics ?? {};
+  const regionBreakdown = analysis.region_breakdown ?? {};
+  const preprocess = payload.preprocess ?? summary.yolo_pores?.preprocess ?? {};
+
+  const poreRegions = {};
+  const wrinkleRegions = [];
+
+  for (const [regionKey, regionData] of Object.entries(regionBreakdown)) {
+    if (!regionData || typeof regionData !== 'object') {
+      continue;
+    }
+
+    const poreMetricsByRegion = regionData.pores?.metrics ?? {};
+    const wrinkleMetricsByRegion = regionData.wrinkles?.metrics ?? {};
+    const wrinkleMaskKey = regionData.wrinkles?.mask_key ?? null;
+
+    poreRegions[regionKey] = {
+      bbox_full: regionData.bbox_full ?? null,
+      pore_count: poreMetricsByRegion.count ?? 0,
+      visible_count: poreMetricsByRegion.visible_count ?? 0,
+      visible_fraction: poreMetricsByRegion.visible_fraction ?? null,
+      quality_visibility: regionData.quality?.visibility ?? null,
+    };
+
+    wrinkleRegions.push({
+      key: regionKey,
+      label: WRINKLE_REGION_LABELS[regionKey] ?? regionKey,
+      mask_key: wrinkleMaskKey,
+      wrinkle_count: wrinkleMetricsByRegion.count ?? 0,
+      bbox_full: regionData.bbox_full ?? null,
+      quality_visibility: regionData.quality?.visibility ?? null,
+      density_per_mpx: wrinkleMetricsByRegion.density_per_mpx ?? null,
+      mean_length_px: wrinkleMetricsByRegion.mean_length_px ?? null,
+      median_length_px: wrinkleMetricsByRegion.median_length_px ?? null,
+      p90_length_px: wrinkleMetricsByRegion.p90_length_px ?? null,
+      median_score: wrinkleMetricsByRegion.median_score ?? null,
+      median_linearity_score: wrinkleMetricsByRegion.median_linearity_score ?? null,
+      orientation_std_deg: wrinkleMetricsByRegion.orientation_std_deg ?? null,
+      preview_url: toAbsoluteApiUrl(apiUrl, wrinkleMaskKey ? payload.mask_overlay_preview_urls?.[wrinkleMaskKey] : null),
+      url: toAbsoluteApiUrl(apiUrl, wrinkleMaskKey ? payload.mask_overlay_urls?.[wrinkleMaskKey] : null),
+    });
+  }
+
+  wrinkleRegions.sort((left, right) => {
+    const countDiff = (right.wrinkle_count ?? 0) - (left.wrinkle_count ?? 0);
+    if (countDiff !== 0) return countDiff;
+    return left.label.localeCompare(right.label);
+  });
+
+  const wrinkleTotal = toFiniteNumber(aggregate.wrinkle_total) ?? toFiniteNumber(analysis.wrinkle_metrics?.count) ?? 0;
+
+  return {
+    poresData: {
+      job_id: payload.job_id ?? null,
+      pore_total: aggregate.pore_total ?? 0,
+      pore_severity_1_5: aggregate.pore_severity_1_5 ?? null,
+      pore_size_severity_1_5: aggregate.pore_size_severity_1_5 ?? null,
+      score_label: poreSeverity.score_label ?? null,
+      score_0_100: poreSeverity.score_0_100 ?? null,
+      visible_count: poreMetrics.visible_count ?? null,
+      visible_fraction: poreMetrics.visible_fraction ?? null,
+      large_pores_present: assessment.large_pores_present ?? null,
+      pores_visibility: assessment.pores_visibility ?? null,
+      regions: poreRegions,
+      preprocess: {
+        crop_bbox: preprocess.crop_bbox ?? null,
+        resized_scale: preprocess.resized_scale ?? null,
+        resized_from: preprocess.resized_from ?? null,
+      },
+      overlay_preview_url: toAbsoluteApiUrl(apiUrl, payload.selected_overlay_preview_url),
+      overlay_url: toAbsoluteApiUrl(apiUrl, payload.selected_overlay_url),
+      overlay_circles_preview_url: toAbsoluteApiUrl(apiUrl, payload.overlay_preview_urls?.pores_circles),
+    },
+    wrinklesData: {
+      predictions: [],
+      image: { width: 0, height: 0 },
+      wrinkleSeverity: {
+        overall: {
+          severity: deriveWrinkleSeverityFromTotal(wrinkleTotal),
+        },
+      },
+      service_overlays: {
+        source: 'poreswrinkles',
+        wrinkle_total: wrinkleTotal,
+        wrinkles_visibility: assessment.wrinkles_visibility ?? null,
+        estimated_age_band: assessment.estimated_age_band ?? null,
+        skin_quality_score_0_100: assessment.skin_quality_score_0_100 ?? null,
+        selected_region: 'full_face',
+        selected_preview_url: toAbsoluteApiUrl(
+          apiUrl,
+          payload.mask_overlay_preview_urls?.wrinkles ?? payload.overlay_preview_urls?.wrinkles ?? payload.selected_overlay_preview_url
+        ),
+        selected_url: toAbsoluteApiUrl(
+          apiUrl,
+          payload.mask_overlay_urls?.wrinkles ?? payload.overlay_urls?.wrinkles ?? payload.selected_overlay_url
+        ),
+        full_face_preview_url: toAbsoluteApiUrl(
+          apiUrl,
+          payload.mask_overlay_preview_urls?.wrinkles ?? payload.overlay_preview_urls?.wrinkles ?? payload.selected_overlay_preview_url
+        ),
+        full_face_url: toAbsoluteApiUrl(
+          apiUrl,
+          payload.mask_overlay_urls?.wrinkles ?? payload.overlay_urls?.wrinkles ?? payload.selected_overlay_url
+        ),
+        regions: wrinkleRegions,
+      },
+      wrinkleMetrics: analysis.wrinkle_metrics ?? null,
+      wrinkleAssessment: assessment,
+    },
+  };
+}
+
+function mergeWrinklesData(legacyWrinklesData, combinedWrinklesData) {
+  if (!combinedWrinklesData) {
+    return legacyWrinklesData;
+  }
+
+  if (!legacyWrinklesData) {
+    return combinedWrinklesData;
+  }
+
+  const legacyPredictions = Array.isArray(legacyWrinklesData.predictions)
+    ? legacyWrinklesData.predictions
+    : [];
+  const combinedPredictions = Array.isArray(combinedWrinklesData.predictions)
+    ? combinedWrinklesData.predictions
+    : [];
+  const legacySeverity = toFiniteNumber(legacyWrinklesData.wrinkleSeverity?.overall?.severity);
+  const combinedSeverity = toFiniteNumber(combinedWrinklesData.wrinkleSeverity?.overall?.severity);
+  const hasLegacyDetections = legacyPredictions.length > 0;
+  const shouldUseLegacySeverity =
+    !legacyWrinklesData.error && (hasLegacyDetections || combinedSeverity === null);
+
+  const merged = {
+    ...combinedWrinklesData,
+    ...legacyWrinklesData,
+    service_overlays: combinedWrinklesData.service_overlays,
+    wrinkleMetrics: combinedWrinklesData.wrinkleMetrics,
+    wrinkleAssessment: combinedWrinklesData.wrinkleAssessment,
+    predictions:
+      hasLegacyDetections ? legacyPredictions : combinedPredictions,
+    image:
+      legacyWrinklesData.image?.width && legacyWrinklesData.image?.height
+        ? legacyWrinklesData.image
+        : combinedWrinklesData.image,
+    wrinkleSeverity:
+      shouldUseLegacySeverity && legacySeverity !== null
+        ? legacyWrinklesData.wrinkleSeverity
+        : combinedWrinklesData.wrinkleSeverity,
+  };
+
+  if (legacyWrinklesData.error && combinedWrinklesData.service_overlays?.selected_preview_url) {
+    delete merged.error;
+  }
+
+  return merged;
+}
+
+module.exports = {
+  deriveWrinkleSeverityFromTotal,
+  mapCombinedPoresWrinklesResult,
+  mergeWrinklesData,
+  toAbsoluteApiUrl,
+};

--- a/api/package.json
+++ b/api/package.json
@@ -7,6 +7,8 @@
     "build": "npm prune --production",
     "deploy": "npm ci --only=production",
     "test": "jest --runInBand --detectOpenHandles",
+    "smoke:e2e": "node tests/smoke-e2e-upload-infer.js",
+    "smoke:local-infer": "node tests/smoke-local-infer-with-live-upstreams.js",
     "lint": "eslint . --ext .js"
   },
   "dependencies": {

--- a/api/tests/README.md
+++ b/api/tests/README.md
@@ -141,9 +141,13 @@ Override supportati:
 - `PORES_API_CLOUDRUN_TASK`
 - `PORES_BREAKER_TIMEOUT_MS`
 - `INFER_SYNC_BUDGET_MS`
+- `INFER_RECOMMENDATIONS_RESERVE_MS`
 
 Note:
 - Lo script forza `NODE_ENV=test` e `DISABLE_INFER_CACHE=true`.
+- Lo smoke usa `INFER_SYNC_BUDGET_MS=300000` di default: il path GPU combinato
+  puo superare i 120 secondi, quindi budget piu bassi possono produrre un
+  fallback `partial: true` pur con il backend GPU sano.
 - Se gli endpoint legacy `acne/laxity/wrinkles` non sono configurati localmente, quelle chiamate andranno in fallback, ma il path GPU `pores+wrinkles` verrà comunque validato.
 - Questo smoke è utile per distinguere un problema di codice locale da un problema di deploy/config del Function App.
 

--- a/api/tests/README.md
+++ b/api/tests/README.md
@@ -88,6 +88,65 @@ Note:
 - Non serve disattivare la cache in produzione: l’URL del blob cambia a ogni iterazione.
 - Se vuoi testare un’altra immagine, imposta `IMAGE_URL` (deve essere pubblicamente accessibile).
 
+## Smoke test Node.js: upload-url -> infer
+Per una verifica rapida post-deploy senza k6:
+
+```bash
+cd api
+npm run smoke:e2e
+```
+
+Override supportati:
+- `INFER_URL`
+- `UPLOAD_URL`
+- `IMAGE_URL`
+- `UPLOAD_MIME_TYPE`
+- `REQUEST_TIMEOUT_MS`
+- `INCLUDE_RECOMMENDATIONS`
+- `EXPECT_WRINKLE_SERVICE_OVERLAYS`
+
+Esempio per validare il nuovo path pores+wrinkles dopo deploy:
+
+```bash
+cd api
+EXPECT_WRINKLE_SERVICE_OVERLAYS=true INCLUDE_RECOMMENDATIONS=false npm run smoke:e2e
+```
+
+Criteri di successo per il cutover GPU:
+- `infer_status = 200`
+- `partial = false`
+- `skipped_apis` assente o vuoto
+- `has_pores_data = true`
+- `has_wrinkle_service_overlays = true`
+- `pores_overlay_url` e `wrinkle_service_overlay_url` valorizzati
+- `overlay_checks[].ok = true`
+
+## Smoke test Node.js: local infer module -> live upload-url + live GPU VM
+Per verificare il codice locale di `api/infer` senza `func start`, ma usando:
+- `api/upload-url` live per creare il blob
+- il modulo locale `api/infer/index.js`
+- il backend GPU VM live per `pores+wrinkles`
+
+```bash
+cd api
+npm run smoke:local-infer
+```
+
+Override supportati:
+- `UPLOAD_URL`
+- `IMAGE_URL`
+- `UPLOAD_MIME_TYPE`
+- `REQUEST_TIMEOUT_MS`
+- `PORES_API_URL`
+- `PORES_API_CLOUDRUN_TASK`
+- `PORES_BREAKER_TIMEOUT_MS`
+- `INFER_SYNC_BUDGET_MS`
+
+Note:
+- Lo script forza `NODE_ENV=test` e `DISABLE_INFER_CACHE=true`.
+- Se gli endpoint legacy `acne/laxity/wrinkles` non sono configurati localmente, quelle chiamate andranno in fallback, ma il path GPU `pores+wrinkles` verrà comunque validato.
+- Questo smoke è utile per distinguere un problema di codice locale da un problema di deploy/config del Function App.
+
 ## Analisi con Application Insights
 Usa le query KQL in `api/tests/application-insights-queries.kql` impostando la finestra temporale del test. Focus:
 - `requests`: tempi e codici di risposta di `/api/infer`
@@ -104,5 +163,3 @@ Punti chiave da verificare:
 ## Suggerimenti
 - Se vuoi evitare il rate-limit in ambiente di test, valuta di eseguire contro un ambiente con `NODE_ENV=test` lato server (se supportato) o riduci i VUs.
 - Puoi esportare i risultati anche in formati aggiuntivi con `handleSummary`.
-
-

--- a/api/tests/infer.poresWrinklesMapper.test.js
+++ b/api/tests/infer.poresWrinklesMapper.test.js
@@ -1,0 +1,154 @@
+const {
+  deriveWrinkleSeverityFromTotal,
+  mapCombinedPoresWrinklesResult,
+  mergeWrinklesData,
+} = require('../infer/poresWrinklesMapper');
+
+describe('poresWrinklesMapper', () => {
+  const apiUrl = 'https://gpu.example.com';
+
+  const samplePayload = {
+    selected_overlay_preview_url: '/v1/results/job-123/overlay/combined?format=jpg',
+    selected_overlay_url: '/v1/results/job-123/overlay/combined',
+    overlay_preview_urls: {
+      pores_circles: '/v1/results/job-123/overlay/pores_circles?format=jpg',
+      wrinkles: '/v1/results/job-123/overlay/wrinkles?format=jpg',
+    },
+    overlay_urls: {
+      wrinkles: '/v1/results/job-123/overlay/wrinkles',
+    },
+    mask_overlay_preview_urls: {
+      wrinkles: '/v1/results/job-123/mask-overlay/wrinkles?format=jpg',
+      wrinkles_forehead: '/v1/results/job-123/mask-overlay/wrinkles_forehead?format=jpg',
+    },
+    mask_overlay_urls: {
+      wrinkles: '/v1/results/job-123/mask-overlay/wrinkles',
+      wrinkles_forehead: '/v1/results/job-123/mask-overlay/wrinkles_forehead',
+    },
+    summary: {
+      aggregate: {
+        pore_total: 12,
+        pore_severity_1_5: 2,
+        pore_size_severity_1_5: 3,
+        wrinkle_total: 18,
+      },
+      analysis: {
+        assessment: {
+          pores_visibility: 'medium',
+          wrinkles_visibility: 'medium',
+          estimated_age_band: '18-35',
+          skin_quality_score_0_100: 61,
+          large_pores_present: false,
+        },
+        pore_severity: {
+          score_label: 'mild',
+          score_0_100: 41,
+        },
+        pore_metrics: {
+          visible_count: 9,
+          visible_fraction: 0.75,
+        },
+        wrinkle_metrics: {
+          count: 18,
+          density_per_mpx: 44.5,
+        },
+        region_breakdown: {
+          forehead: {
+            bbox_full: { x0: 10, y0: 20, x1: 100, y1: 120 },
+            pores: {
+              metrics: {
+                count: 4,
+                visible_count: 3,
+                visible_fraction: 0.75,
+              },
+            },
+            quality: {
+              visibility: 'high',
+            },
+            wrinkles: {
+              mask_key: 'wrinkles_forehead',
+              metrics: {
+                count: 18,
+                density_per_mpx: 123.4,
+                mean_length_px: 35.2,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  test('maps combined service payload into pores and wrinkle contracts', () => {
+    const mapped = mapCombinedPoresWrinklesResult({ ...samplePayload, job_id: 'job-123' }, apiUrl);
+
+    expect(mapped.poresData.job_id).toBe('job-123');
+    expect(mapped.poresData.overlay_circles_preview_url).toBe(
+      'https://gpu.example.com/v1/results/job-123/overlay/pores_circles?format=jpg'
+    );
+    expect(mapped.poresData.regions.forehead.pore_count).toBe(4);
+
+    expect(mapped.wrinklesData.wrinkleSeverity.overall.severity).toBe(3);
+    expect(mapped.wrinklesData.service_overlays.selected_preview_url).toBe(
+      'https://gpu.example.com/v1/results/job-123/mask-overlay/wrinkles?format=jpg'
+    );
+    expect(mapped.wrinklesData.service_overlays.regions).toHaveLength(1);
+    expect(mapped.wrinklesData.service_overlays.regions[0]).toMatchObject({
+      key: 'forehead',
+      label: 'Forehead',
+      wrinkle_count: 18,
+      preview_url: 'https://gpu.example.com/v1/results/job-123/mask-overlay/wrinkles_forehead?format=jpg',
+    });
+  });
+
+  test('merge keeps legacy polygons and severity while attaching service overlays', () => {
+    const combined = mapCombinedPoresWrinklesResult(samplePayload, apiUrl).wrinklesData;
+    const legacy = {
+      predictions: [
+        {
+          class: 'forehead',
+          confidence: 0.9,
+          width: 10,
+          height: 10,
+          x: 100,
+          y: 100,
+        },
+      ],
+      image: { width: 1024, height: 1024 },
+      wrinkleSeverity: { overall: { severity: 4 } },
+      severity: 'Severe',
+    };
+
+    const merged = mergeWrinklesData(legacy, combined);
+
+    expect(merged.predictions).toHaveLength(1);
+    expect(merged.image).toEqual({ width: 1024, height: 1024 });
+    expect(merged.wrinkleSeverity.overall.severity).toBe(4);
+    expect(merged.service_overlays.regions[0].key).toBe('forehead');
+  });
+
+  test('merge prefers combined severity when legacy payload is only a fallback error', () => {
+    const combined = mapCombinedPoresWrinklesResult(samplePayload, apiUrl).wrinklesData;
+    const legacyFallback = {
+      predictions: [],
+      image: { width: 0, height: 0 },
+      wrinkleSeverity: { overall: { severity: 1 } },
+      error: 'Wrinkles API call failed',
+    };
+
+    const merged = mergeWrinklesData(legacyFallback, combined);
+
+    expect(merged.predictions).toEqual([]);
+    expect(merged.wrinkleSeverity.overall.severity).toBe(3);
+    expect(merged.error).toBeUndefined();
+    expect(merged.service_overlays.selected_preview_url).toContain('/mask-overlay/wrinkles');
+  });
+
+  test('derives stable wrinkle severity buckets from totals', () => {
+    expect(deriveWrinkleSeverityFromTotal(0)).toBe(1);
+    expect(deriveWrinkleSeverityFromTotal(8)).toBe(2);
+    expect(deriveWrinkleSeverityFromTotal(18)).toBe(3);
+    expect(deriveWrinkleSeverityFromTotal(34)).toBe(4);
+    expect(deriveWrinkleSeverityFromTotal(51)).toBe(5);
+  });
+});

--- a/api/tests/smoke-e2e-upload-infer.js
+++ b/api/tests/smoke-e2e-upload-infer.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+const DEFAULT_INFER_URL =
+  process.env.INFER_URL ||
+  'https://new-skincare-advisor-api-fqc8dffvg5ghene2.westeurope-01.azurewebsites.net/api/infer';
+const DEFAULT_UPLOAD_URL =
+  process.env.UPLOAD_URL ||
+  'https://new-skincare-advisor-api-fqc8dffvg5ghene2.westeurope-01.azurewebsites.net/api/upload-url';
+const DEFAULT_IMAGE_URL =
+  process.env.IMAGE_URL ||
+  'https://stdermaselfprdwesteurope.blob.core.windows.net/selfies/uploads/2025-10-31/f9b1f0f9-8c57-4a1e-9bab-53fbe70229e8.jpeg';
+const UPLOAD_MIME_TYPE = process.env.UPLOAD_MIME_TYPE || 'image/jpeg';
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '180000', 10);
+const INCLUDE_RECOMMENDATIONS =
+  (process.env.INCLUDE_RECOMMENDATIONS || 'true').toLowerCase() === 'true';
+const EXPECT_WRINKLE_SERVICE_OVERLAYS =
+  (process.env.EXPECT_WRINKLE_SERVICE_OVERLAYS || 'false').toLowerCase() === 'true';
+
+async function main() {
+  const sourceImage = await fetchWithTimeout(DEFAULT_IMAGE_URL);
+  if (!sourceImage.ok) {
+    throw new Error(`Failed to download source image: ${sourceImage.status} ${sourceImage.statusText}`);
+  }
+
+  const imageBytes = Buffer.from(await sourceImage.arrayBuffer());
+
+  const uploadRes = await fetchJson(DEFAULT_UPLOAD_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mimeType: UPLOAD_MIME_TYPE }),
+  });
+
+  if (!uploadRes.body?.uploadUrl || !uploadRes.body?.inferenceId) {
+    throw new Error(`Upload URL response missing fields: ${JSON.stringify(uploadRes.body)}`);
+  }
+
+  const putRes = await fetchWithTimeout(uploadRes.body.uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': UPLOAD_MIME_TYPE,
+      'x-ms-blob-type': 'BlockBlob',
+      'Content-Length': String(imageBytes.length),
+    },
+    body: imageBytes,
+  });
+
+  if (!putRes.ok) {
+    throw new Error(`Blob upload failed: ${putRes.status} ${putRes.statusText}`);
+  }
+
+  const inferPayload = {
+    inferenceId: uploadRes.body.inferenceId,
+    includeRecommendations: INCLUDE_RECOMMENDATIONS,
+    userData: {
+      first_name: 'Lorenzo',
+      last_name: 'Musso',
+      gender: 'Maschio',
+      budget_level: 'High',
+      ageRange: '36 - 45',
+      shop_domain: 'dermaself',
+    },
+    metadata: {
+      apiVersion: '1.0',
+      source: 'node-smoke-e2e',
+      clientTimestamp: Date.now(),
+    },
+  };
+
+  const inferRes = await fetchJson(DEFAULT_INFER_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(inferPayload),
+  });
+
+  const response = inferRes.body;
+  const poresOverlayUrl = response?.poresData?.overlay_circles_preview_url || null;
+  const wrinkleOverlayUrl = response?.wrinklesData?.service_overlays?.selected_preview_url || null;
+
+  if (!response?.inference_id) {
+    throw new Error(`Infer response missing inference_id: ${JSON.stringify(response).slice(0, 1000)}`);
+  }
+
+  if (EXPECT_WRINKLE_SERVICE_OVERLAYS && !wrinkleOverlayUrl) {
+    throw new Error('Expected wrinklesData.service_overlays.selected_preview_url in infer response');
+  }
+
+  const overlayChecks = [];
+  if (poresOverlayUrl) {
+    overlayChecks.push(checkImageUrl('pores_overlay', poresOverlayUrl));
+  }
+  if (wrinkleOverlayUrl) {
+    overlayChecks.push(checkImageUrl('wrinkle_overlay', wrinkleOverlayUrl));
+  }
+
+  const overlayResults = await Promise.all(overlayChecks);
+
+  console.log(
+    JSON.stringify(
+      {
+        upload_url_status: uploadRes.status,
+        upload_put_status: putRes.status,
+        infer_status: inferRes.status,
+        inference_id: response.inference_id,
+        partial: response.partial,
+        skipped_apis: response.skippedApis || null,
+        has_pores_data: response.poresData !== null && response.poresData !== undefined,
+        pores_data_keys: response.poresData ? Object.keys(response.poresData) : null,
+        wrinkles_data_keys: response.wrinklesData ? Object.keys(response.wrinklesData) : null,
+        pores_overlay_url: poresOverlayUrl,
+        wrinkle_service_overlay_url: wrinkleOverlayUrl,
+        has_wrinkle_service_overlays: Boolean(response?.wrinklesData?.service_overlays),
+        wrinkle_service_region_count: response?.wrinklesData?.service_overlays?.regions?.length || 0,
+        overlay_checks: overlayResults,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function checkImageUrl(name, url) {
+  const res = await fetchWithTimeout(url, { method: 'GET' });
+  return {
+    name,
+    url,
+    status: res.status,
+    content_type: res.headers.get('content-type'),
+    ok: res.ok,
+  };
+}
+
+async function fetchJson(url, init) {
+  const response = await fetchWithTimeout(url, init);
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch (error) {
+    throw new Error(`Invalid JSON from ${url}: ${text.slice(0, 400)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`Request failed ${response.status} ${response.statusText}: ${JSON.stringify(body).slice(0, 1000)}`);
+  }
+  return { status: response.status, body };
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exitCode = 1;
+});

--- a/api/tests/smoke-local-infer-with-live-upstreams.js
+++ b/api/tests/smoke-local-infer-with-live-upstreams.js
@@ -17,7 +17,7 @@ process.env.PORES_API_CLOUDRUN_TASK =
   process.env.PORES_API_CLOUDRUN_TASK || 'pores+wrinkles';
 process.env.PORES_BREAKER_TIMEOUT_MS =
   process.env.PORES_BREAKER_TIMEOUT_MS || '240000';
-process.env.INFER_SYNC_BUDGET_MS = process.env.INFER_SYNC_BUDGET_MS || '120000';
+process.env.INFER_SYNC_BUDGET_MS = process.env.INFER_SYNC_BUDGET_MS || '300000';
 process.env.INFER_RECOMMENDATIONS_RESERVE_MS =
   process.env.INFER_RECOMMENDATIONS_RESERVE_MS || '1000';
 

--- a/api/tests/smoke-local-infer-with-live-upstreams.js
+++ b/api/tests/smoke-local-infer-with-live-upstreams.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+const DEFAULT_UPLOAD_URL =
+  process.env.UPLOAD_URL ||
+  'https://new-skincare-advisor-api-fqc8dffvg5ghene2.westeurope-01.azurewebsites.net/api/upload-url';
+const DEFAULT_SOURCE_IMAGE_URL =
+  process.env.IMAGE_URL ||
+  'https://stdermaselfprdwesteurope.blob.core.windows.net/selfies/uploads/2025-10-31/f9b1f0f9-8c57-4a1e-9bab-53fbe70229e8.jpeg';
+const UPLOAD_MIME_TYPE = process.env.UPLOAD_MIME_TYPE || 'image/jpeg';
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '180000', 10);
+
+// These env vars are read at module initialization time inside ./infer.
+process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.DISABLE_INFER_CACHE = process.env.DISABLE_INFER_CACHE || 'true';
+process.env.PORES_API_URL = process.env.PORES_API_URL || 'http://34.34.123.132:8080';
+process.env.PORES_API_CLOUDRUN_TASK =
+  process.env.PORES_API_CLOUDRUN_TASK || 'pores+wrinkles';
+process.env.PORES_BREAKER_TIMEOUT_MS =
+  process.env.PORES_BREAKER_TIMEOUT_MS || '240000';
+process.env.INFER_SYNC_BUDGET_MS = process.env.INFER_SYNC_BUDGET_MS || '120000';
+process.env.INFER_RECOMMENDATIONS_RESERVE_MS =
+  process.env.INFER_RECOMMENDATIONS_RESERVE_MS || '1000';
+
+const infer = require('../infer');
+
+async function main() {
+  const sourceImage = await fetchWithTimeout(DEFAULT_SOURCE_IMAGE_URL);
+  if (!sourceImage.ok) {
+    throw new Error(
+      `Failed to download source image: ${sourceImage.status} ${sourceImage.statusText}`
+    );
+  }
+
+  const imageBytes = Buffer.from(await sourceImage.arrayBuffer());
+
+  const uploadRes = await fetchJson(DEFAULT_UPLOAD_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ mimeType: UPLOAD_MIME_TYPE }),
+  });
+
+  if (!uploadRes.body?.uploadUrl || !uploadRes.body?.inferenceId) {
+    throw new Error(`Upload URL response missing fields: ${JSON.stringify(uploadRes.body)}`);
+  }
+
+  const putRes = await fetchWithTimeout(uploadRes.body.uploadUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': UPLOAD_MIME_TYPE,
+      'x-ms-blob-type': 'BlockBlob',
+      'Content-Length': String(imageBytes.length),
+    },
+    body: imageBytes,
+  });
+
+  if (!putRes.ok) {
+    throw new Error(`Blob upload failed: ${putRes.status} ${putRes.statusText}`);
+  }
+
+  const imageUrl = uploadRes.body.uploadUrl.split('?')[0];
+
+  const context = {
+    req: {
+      headers: {
+        'x-forwarded-for': '127.0.0.1',
+      },
+    },
+    res: undefined,
+    executionContext: { functionName: 'infer' },
+    bindingData: {},
+    log: (...args) => console.log('[context.log]', ...args),
+    done: () => {},
+  };
+
+  const req = {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-forwarded-for': '127.0.0.1',
+    },
+    body: {
+      imageUrl,
+      inferenceId: uploadRes.body.inferenceId,
+      includeRecommendations: false,
+      metadata: {
+        source: 'node-local-smoke-e2e',
+        mimeType: UPLOAD_MIME_TYPE,
+        clientTimestamp: Date.now(),
+      },
+    },
+  };
+
+  await infer(context, req);
+
+  const response = context.res?.body;
+  if (!response?.inference_id) {
+    throw new Error(`Local infer response missing inference_id: ${JSON.stringify(response).slice(0, 1000)}`);
+  }
+
+  const poresOverlayUrl = response?.poresData?.overlay_preview_url || null;
+  const wrinkleOverlayUrl =
+    response?.wrinklesData?.service_overlays?.selected_preview_url || null;
+
+  const overlayChecks = [];
+  if (poresOverlayUrl) {
+    overlayChecks.push(checkImageUrl('pores_overlay', poresOverlayUrl));
+  }
+  if (wrinkleOverlayUrl) {
+    overlayChecks.push(checkImageUrl('wrinkle_overlay', wrinkleOverlayUrl));
+  }
+
+  const overlayResults = await Promise.all(overlayChecks);
+
+  console.log(
+    JSON.stringify(
+      {
+        upload_url_status: uploadRes.status,
+        upload_put_status: putRes.status,
+        local_infer_status: context.res?.status || 200,
+        inference_id: response.inference_id,
+        partial: response.partial,
+        skipped_apis: response.skippedApis || response.skipped_apis || null,
+        has_pores_data: response.poresData !== null && response.poresData !== undefined,
+        pores_data_keys: response.poresData ? Object.keys(response.poresData) : null,
+        wrinkles_data_keys: response.wrinklesData ? Object.keys(response.wrinklesData) : null,
+        pores_overlay_url: poresOverlayUrl,
+        wrinkle_service_overlay_url: wrinkleOverlayUrl,
+        has_wrinkle_service_overlays: Boolean(response?.wrinklesData?.service_overlays),
+        wrinkle_service_region_count:
+          response?.wrinklesData?.service_overlays?.regions?.length || 0,
+        overlay_checks: overlayResults,
+      },
+      null,
+      2
+    )
+  );
+}
+
+async function checkImageUrl(name, url) {
+  const res = await fetchWithTimeout(url, { method: 'GET' });
+  return {
+    name,
+    url,
+    status: res.status,
+    content_type: res.headers.get('content-type'),
+    ok: res.ok,
+  };
+}
+
+async function fetchJson(url, init) {
+  const response = await fetchWithTimeout(url, init);
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch (error) {
+    throw new Error(`Invalid JSON from ${url}: ${text.slice(0, 400)}`);
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Request failed ${response.status} ${response.statusText}: ${JSON.stringify(body).slice(0, 1000)}`
+    );
+  }
+  return { status: response.status, body };
+}
+
+async function fetchWithTimeout(url, init = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exit(1);
+  });

--- a/frontend/src/components/AnalysisResults.tsx
+++ b/frontend/src/components/AnalysisResults.tsx
@@ -288,7 +288,9 @@ export default function AnalysisResults({ result, onReset }: AnalysisResultsProp
                 analysisData={{
                   predictions: result.rawAnalysisData.predictions || [],
                   erythema: result.rawAnalysisData.redness?.erythema || false,
+                  wrinklesData: result.rawAnalysisData.wrinklesData || undefined,
                   wrinkles: result.rawAnalysisData.wrinkles || undefined,
+                  poresData: result.rawAnalysisData.poresData || undefined,
                   image: result.rawAnalysisData.image || { width: 0, height: 0 }
                 }}
                 className="mb-4"
@@ -576,4 +578,4 @@ export default function AnalysisResults({ result, onReset }: AnalysisResultsProp
       </motion.div>
     </div>
   );
-} 
+}

--- a/frontend/src/components/SkinAnalysisImage.tsx
+++ b/frontend/src/components/SkinAnalysisImage.tsx
@@ -28,6 +28,27 @@ interface WrinklesPrediction {
   points?: Array<{ x: number; y: number }>;
 }
 
+interface WrinkleServiceRegion {
+  key: string;
+  label: string;
+  mask_key: string | null;
+  wrinkle_count: number;
+  preview_url: string | null;
+  url: string | null;
+}
+
+interface WrinkleServiceOverlays {
+  source: string;
+  wrinkle_total: number;
+  wrinkles_visibility: string | null;
+  selected_region: string;
+  selected_preview_url: string | null;
+  selected_url: string | null;
+  full_face_preview_url: string | null;
+  full_face_url: string | null;
+  regions: WrinkleServiceRegion[];
+}
+
 interface AnalysisData {
   predictions: Prediction[];
   laxityRednessData?: {
@@ -42,13 +63,14 @@ interface AnalysisData {
     predictions: WrinklesPrediction[];
     image: { width: number; height: number };
     wrinkleSeverity?: {
-      overall: { severity: number };
+      overall?: { severity?: number };
     };
     counts?: Record<string, number>;
     severity?: string;
     has_forehead_wrinkles?: boolean;
     has_expression_lines?: boolean;
     has_under_eye_concerns?: boolean;
+    service_overlays?: WrinkleServiceOverlays;
   };
   wrinkles?: {
     predictions: WrinklesPrediction[];
@@ -60,6 +82,7 @@ interface AnalysisData {
     has_forehead_wrinkles?: boolean;
     has_expression_lines?: boolean;
     has_under_eye_concerns?: boolean;
+    service_overlays?: WrinkleServiceOverlays;
   };
   poresData?: {
     pore_total: number;
@@ -145,6 +168,7 @@ export default function SkinAnalysisImage({
   const [showOverlays, setShowOverlays] = useState(true);
   const [hoveredDetection, setHoveredDetection] = useState<string | null>(null);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const [selectedWrinkleRegion, setSelectedWrinkleRegion] = useState('full_face');
   const imageRef = useRef<HTMLImageElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -162,9 +186,52 @@ export default function SkinAnalysisImage({
   // Keep for convenience; now it's uniform (scaleX === scaleY)
   const [scaleFactors, setScaleFactors] = useState({ x: 1, y: 1 });
 
+  const wrinklesPayload = analysisData.wrinklesData || analysisData.wrinkles;
+  const wrinkleServiceOverlays = wrinklesPayload?.service_overlays;
+  const hasWrinkleServiceOverlay = Boolean(
+    wrinkleServiceOverlays?.full_face_preview_url ||
+    wrinkleServiceOverlays?.selected_preview_url ||
+    wrinkleServiceOverlays?.regions?.some((region) => region.preview_url || region.url)
+  );
+
+  useEffect(() => {
+    if (!hasWrinkleServiceOverlay) {
+      if (selectedWrinkleRegion !== 'full_face') {
+        setSelectedWrinkleRegion('full_face');
+      }
+      return;
+    }
+
+    const regionExists =
+      selectedWrinkleRegion === 'full_face' ||
+      wrinkleServiceOverlays?.regions?.some((region) => region.key === selectedWrinkleRegion);
+
+    if (!regionExists) {
+      setSelectedWrinkleRegion(wrinkleServiceOverlays?.selected_region || 'full_face');
+    }
+  }, [hasWrinkleServiceOverlay, selectedWrinkleRegion, wrinkleServiceOverlays]);
+
+  const activeWrinkleRegion =
+    selectedWrinkleRegion === 'full_face'
+      ? null
+      : wrinkleServiceOverlays?.regions?.find((region) => region.key === selectedWrinkleRegion) ?? null;
+
+  const selectedWrinkleOverlayUrl =
+    activeWrinkleRegion?.preview_url ||
+    activeWrinkleRegion?.url ||
+    wrinkleServiceOverlays?.full_face_preview_url ||
+    wrinkleServiceOverlays?.selected_preview_url ||
+    wrinkleServiceOverlays?.full_face_url ||
+    wrinkleServiceOverlays?.selected_url ||
+    null;
+
   const carouselImages = [
     { url: imageUrl, label: t('image.imperfections'), view: 'acne' as const },
-    { url: imageUrl, label: t('image.wrinkles_analysis'), view: 'wrinkles' as const },
+    {
+      url: selectedWrinkleOverlayUrl || imageUrl,
+      label: t('image.wrinkles_analysis'),
+      view: 'wrinkles' as const
+    },
     ...(analysisData.poresData?.overlay_circles_preview_url
       ? [{ url: analysisData.poresData.overlay_circles_preview_url, label: t('image.pores_analysis'), view: 'pores' as const }]
       : [])
@@ -525,6 +592,13 @@ export default function SkinAnalysisImage({
       .replace(/^./, (match) => match.toUpperCase());
   };
 
+  const hasStaticOverlayImage =
+    currentView === 'pores' ||
+    (currentView === 'wrinkles' && Boolean(selectedWrinkleOverlayUrl));
+
+  const wrinkleLegendRegions =
+    wrinkleServiceOverlays?.regions?.filter((region) => (region.preview_url || region.url) && region.wrinkle_count > 0) ?? [];
+
   return (
     <div className={`relative ${className}`}>
       {/* Image Carousel */}
@@ -544,16 +618,25 @@ export default function SkinAnalysisImage({
                 transition={{ duration: 0.3 }}
                 className="w-full"
               >
-                {analysisData.poresData?.overlay_circles_preview_url && (
+                {currentView === 'pores' && analysisData.poresData?.overlay_circles_preview_url && (
                   <img
                     src={analysisData.poresData.overlay_circles_preview_url}
                     alt={t('image.pores_analysis')}
-                    className={`w-full object-contain rounded-xl ${currentView === 'pores' ? 'block' : 'hidden'}`}
+                    className="w-full object-contain rounded-xl"
                     style={{ maxHeight: '384px', margin: '0 auto' }}
                   />
                 )}
 
-                <div className={currentView === 'pores' ? 'hidden' : 'block'}>
+                {currentView === 'wrinkles' && selectedWrinkleOverlayUrl && (
+                  <img
+                    src={selectedWrinkleOverlayUrl}
+                    alt={t('image.wrinkles_analysis')}
+                    className="w-full object-contain rounded-xl"
+                    style={{ maxHeight: '384px', margin: '0 auto' }}
+                  />
+                )}
+
+                <div className={hasStaticOverlayImage ? 'hidden' : 'block'}>
                   {/* Hidden image only for dimensions & load */}
                   <img
                     ref={imageRef}
@@ -656,6 +739,37 @@ export default function SkinAnalysisImage({
               >
                 {t('image.pores_analysis')}
               </div>
+            </div>
+          ) : currentView === 'wrinkles' && hasWrinkleServiceOverlay ? (
+            <div className="flex flex-wrap gap-2 justify-center">
+              <button
+                type="button"
+                onClick={() => setSelectedWrinkleRegion('full_face')}
+                className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                  selectedWrinkleRegion === 'full_face'
+                    ? 'bg-primary-600 text-white shadow'
+                    : 'bg-primary-50 text-primary-700'
+                }`}
+              >
+                {t('image.wrinkles_analysis')}
+                {wrinkleServiceOverlays?.wrinkle_total ? ` · ${wrinkleServiceOverlays.wrinkle_total}` : ''}
+              </button>
+
+              {wrinkleLegendRegions.map((region) => (
+                <button
+                  key={region.key}
+                  type="button"
+                  onClick={() => setSelectedWrinkleRegion(region.key)}
+                  className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                    selectedWrinkleRegion === region.key
+                      ? 'bg-primary-600 text-white shadow'
+                      : 'bg-primary-50 text-primary-700'
+                  }`}
+                >
+                  {region.label}
+                  {region.wrinkle_count ? ` · ${region.wrinkle_count}` : ''}
+                </button>
+              ))}
             </div>
           ) : (
             /* Acne / Wrinkles view: existing class color legend */

--- a/frontend/src/components/SkinAnalysisImage.tsx
+++ b/frontend/src/components/SkinAnalysisImage.tsx
@@ -124,6 +124,7 @@ const ACNE_COLORS = {
 
 const REDNESS_COLOR = '#FF4757';
 const REDNESS_OPACITY = 0.8;
+const PORES_ACCENT_COLOR = '#ffbafa';
 
 // Wrinkles color mapping with transparency
 const WRINKLES_COLORS = {
@@ -566,7 +567,7 @@ export default function SkinAnalysisImage({
         return getWrinkleColor(className);
       case 'pores':
       default:
-        return '#7547F2';
+        return PORES_ACCENT_COLOR;
     }
   };
 
@@ -735,7 +736,7 @@ export default function SkinAnalysisImage({
             <div className="flex flex-wrap gap-2 justify-center">
               <div
                 className="px-3 py-1 rounded-full text-sm font-medium"
-                style={{ backgroundColor: '#00FF00', color: '#000000' }}
+                style={{ backgroundColor: PORES_ACCENT_COLOR, color: '#000000' }}
               >
                 {t('image.pores_analysis')}
               </div>

--- a/frontend/src/components/SpideringChart.tsx
+++ b/frontend/src/components/SpideringChart.tsx
@@ -148,7 +148,7 @@ export default function SpideringChart({
       userValue: userMetrics.pores as number,
       benchmarkValue: (benchmarks.pores as number | null) ?? 2, // 2 = "mild" reference
       max: 5,
-      color: '#7547F2'
+      color: '#ffbafa'
     }] : [])
   ];
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -62,6 +62,93 @@ export interface UploadUrlResponse {
   expiresAt: string;
 }
 
+type WrinkleAnalysisPayload = {
+  predictions: Array<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    confidence: number;
+    class: string;
+    detection_id?: string;
+    points?: Array<{ x: number; y: number }>;
+  }>;
+  image: { width: number; height: number };
+  scaling_factors?: { x: number; y: number };
+  original_resolution?: { width: number; height: number };
+  counts?: Record<string, number>;
+  severity?: string;
+  has_forehead_wrinkles?: boolean;
+  has_expression_lines?: boolean;
+  has_under_eye_concerns?: boolean;
+  wrinkleSeverity?: {
+    overall?: {
+      severity?: number;
+    };
+  };
+  service_overlays?: {
+    source: string;
+    wrinkle_total: number;
+    wrinkles_visibility: string | null;
+    estimated_age_band: string | null;
+    skin_quality_score_0_100: number | null;
+    selected_region: string;
+    selected_preview_url: string | null;
+    selected_url: string | null;
+    full_face_preview_url: string | null;
+    full_face_url: string | null;
+    regions: Array<{
+      key: string;
+      label: string;
+      mask_key: string | null;
+      wrinkle_count: number;
+      bbox_full: { x0: number; y0: number; x1: number; y1: number } | null;
+      quality_visibility: string | null;
+      density_per_mpx: number | null;
+      mean_length_px: number | null;
+      median_length_px: number | null;
+      p90_length_px: number | null;
+      median_score: number | null;
+      median_linearity_score: number | null;
+      orientation_std_deg: number | null;
+      preview_url: string | null;
+      url: string | null;
+    }>;
+  };
+  wrinkleMetrics?: {
+    count?: number;
+    density_per_mpx?: number;
+    roi_area_px?: number;
+    skeleton_fraction?: number;
+    length_px?: {
+      min?: number;
+      max?: number;
+      mean?: number;
+      median?: number;
+      p90?: number;
+    };
+    linearity_score?: {
+      min?: number;
+      max?: number;
+      mean?: number;
+      median?: number;
+      p90?: number;
+    };
+    score?: {
+      min?: number;
+      max?: number;
+      mean?: number;
+      median?: number;
+      p90?: number;
+    };
+  };
+  wrinkleAssessment?: {
+    wrinkles_visibility?: string | null;
+    estimated_age_band?: string | null;
+    skin_quality_score_0_100?: number | null;
+  };
+};
+
 export interface AnalysisResponse {
   // Roboflow inference data
   predictions: Array<any>;
@@ -89,26 +176,8 @@ export interface AnalysisResponse {
     original_resolution?: { width: number; height: number };
   };
   
-  wrinkles?: {
-    predictions: Array<{
-      x: number;
-      y: number;
-      width: number;
-      height: number;
-      confidence: number;
-      class: string;
-      detection_id?: string;
-      points?: Array<{ x: number; y: number }>;
-    }>;
-    image: { width: number; height: number };
-    scaling_factors?: { x: number; y: number };
-    original_resolution?: { width: number; height: number };
-    counts?: Record<string, number>;
-    severity?: string;
-    has_forehead_wrinkles?: boolean;
-    has_expression_lines?: boolean;
-    has_under_eye_concerns?: boolean;
-  };
+  wrinkles?: WrinkleAnalysisPayload;
+  wrinklesData?: WrinkleAnalysisPayload;
   
   // Product recommendations
   recommendations?: {
@@ -536,4 +605,4 @@ export async function retryWithBackoff<T>(
   throw lastError!;
 }
 
-export default api; 
+export default api;


### PR DESCRIPTION
## Summary
- integrate combined pores+wrinkles GPU VM response mapping into api/infer
- pass pores and wrinkle service overlay data through the frontend results flow
- add smoke scripts for deployed Azure infer and local infer module validation
- add a manual GitHub Actions workflow for Azure Function API deployment

## Verification
- cd api && npm test
- cd frontend && npm run build
- cd api && npm run smoke:local-infer
- cd api && INCLUDE_RECOMMENDATIONS=false npm run smoke:e2e

## Notes
- local infer smoke passed against the live GPU VM with partial=false and service overlays present
- deployed Azure infer smoke still shows the current prod app is stale and skipping pores until Lorenzo deploys the updated Function App